### PR TITLE
sd-92 bugfix - navigation styling

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -17761,8 +17761,8 @@ body.theme-accent-white .main-nav .dropdown.current .navbar-touch-caret:hover, b
     border-color: #dee2e6;
   }
   .main-nav .nav-item .nav-link {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-left: 15px;
+    padding-right: 15px;
   }
   .main-nav .nav-item > a,
   .main-nav .dropdown-menu a {

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -16451,6 +16451,7 @@ body.theme-header-white .site-header-search .form-control:-ms-input-placeholder 
   background: transparent;
   border: 0;
   color: #fff;
+  border: 1px solid rgba(85, 85, 85, 0.4);
 }
 
 body.theme-header-red .site-header-search .form-control, body.theme-header-red
@@ -17761,8 +17762,8 @@ body.theme-accent-white .main-nav .dropdown.current .navbar-touch-caret:hover, b
     border-color: #dee2e6;
   }
   .main-nav .nav-item .nav-link {
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
   }
   .main-nav .nav-item > a,
   .main-nav .dropdown-menu a {

--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -74,6 +74,7 @@ body > header {
   button[type="submit"] {
     height: $navbar-height;
     @include form-controls-style();
+    border: 1px solid rgba($gray-600, .4);
 
     // Special case for white/light-grey theme
     body.theme-header-white &,

--- a/src/scss/components/nav.scss
+++ b/src/scss/components/nav.scss
@@ -104,8 +104,8 @@
       box-shadow: none;
       border-top: 1px solid $navbar-dark-color;
       border-color: $navbar-dark-color;
-      margin-left: -20px;
-      margin-right: -20px;
+      margin-left: -($grid-gutter-width / 2);
+      margin-right: -($grid-gutter-width / 2);
     }
 
     .navbar {
@@ -123,8 +123,8 @@
     }
 
     .nav-item .nav-link {
-      padding-left: 15px;
-      padding-right: 15px;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
     }
 
     // Add hover border to left side

--- a/src/scss/components/nav.scss
+++ b/src/scss/components/nav.scss
@@ -104,8 +104,8 @@
       box-shadow: none;
       border-top: 1px solid $navbar-dark-color;
       border-color: $navbar-dark-color;
-      margin-left: -($grid-gutter-width / 2);
-      margin-right: -($grid-gutter-width / 2);
+      margin-left: -20px;
+      margin-right: -20px;
     }
 
     .navbar {
@@ -123,8 +123,8 @@
     }
 
     .nav-item .nav-link {
-      padding-left: 1.5rem;
-      padding-right: 1.5rem;
+      padding-left: 15px;
+      padding-right: 15px;
     }
 
     // Add hover border to left side

--- a/templates/Includes/LanguageSelector.ss
+++ b/templates/Includes/LanguageSelector.ss
@@ -1,5 +1,5 @@
 <% if $Locales %>
-    <div class="btn-group pull-right language-selector" id="header-language-toggle">
+    <div class="btn-group float-right language-selector" id="header-language-toggle">
         <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fa fa-language" aria-hidden="true"></i>
             <span class="hidden-xs hidden-sm">

--- a/templates/Includes/PageUtilities.ss
+++ b/templates/Includes/PageUtilities.ss
@@ -6,7 +6,7 @@
                     <% if $LastEdited %>
                         <% include LastModified %>
                     <% end_if %>
-                    <ul class="list-inline pull-right page-utilities-actions">
+                    <ul class="list-inline float-right page-utilities-actions">
                         <li>
                             <a href="#" class="btn btn-link fa fa-print" onclick="window.print(); return false;">
                                 <span class="sr-only"><%t SilverStripe\\Forms\\GridField\\GridField.Print "Print" %></span>

--- a/templates/Layout/HomePage.ss
+++ b/templates/Layout/HomePage.ss
@@ -3,7 +3,6 @@
     <div class="container">
         <div class="row">
             <section class="col-lg-8">
-                <h1>$Title</h1>
                 <% if $ElementalArea %>
                     <%-- Support for content blocks, if enabled --%>
                     <% if $ElementalArea.RichLinks %>

--- a/templates/SearchForm_header.ss
+++ b/templates/SearchForm_header.ss
@@ -1,4 +1,4 @@
-<form $FormAttributes class="form-inline d-none d-md-block header-search pull-right" role="search">
+<form $FormAttributes class="form-inline d-none d-md-block header-search float-right" role="search">
     <div class="input-group">
         <input name="Search" aria-label="search" type="text" class="form-control" placeholder="<%t CWP_Search.Placeholder "Search..." %>">
         <div class="input-group-append">


### PR DESCRIPTION
Seems like a rebase removed the nav header search styling. Have updated this pr to include this, also updated a deprecated `pull-right` to `float-right` in Bootstrap 4. Have removed `$Title` from `HomePage` if an `ElementalArea` is present. It will now only show if users only access the WYSIWYG editor instead of elemental.