### PR TITLE
bugfix/sd-109: fix comments spacing from above page content.

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -18730,11 +18730,6 @@ body.theme-accent-white .main .pagination .active a {
   margin-bottom: 0.8rem;
 }
 
-.news-events-article:first-child h2,
-.blog-entry:first-child h2 {
-  margin-top: 1.8rem;
-}
-
 .h5.news-events-archive-year {
   margin-top: 3px;
 }

--- a/src/scss/components/pages.scss
+++ b/src/scss/components/pages.scss
@@ -153,14 +153,6 @@
   }
 }
 
-// News/Events/Blog items adjustment to bring only the first of the articles inline with the sidebar
-.news-events-article,
-.blog-entry {
-  &:first-child h2 {
-    margin-top: 1.8rem;
-  }
-}
-
 .h5.news-events-archive-year {
   margin-top: 3px;
 }


### PR DESCRIPTION
The previous code snippet was redundant, as there was a new fix in place to allow holder the first child page heading to not sit against the top of the parent container.